### PR TITLE
Fix typo in recipe error constant

### DIFF
--- a/src/app/api/recipes/ai/route.ts
+++ b/src/app/api/recipes/ai/route.ts
@@ -47,8 +47,8 @@ export async function POST(req: NextRequest) {
   } catch (error) {
     return NextResponse.json<ApiErrorSchema>(
       {
-        message: errorMessages.CANNOT_CREAT_RECIPE.message,
-        description: errorMessages.CANNOT_CREAT_RECIPE.description,
+        message: errorMessages.CANNOT_CREATE_RECIPE.message,
+        description: errorMessages.CANNOT_CREATE_RECIPE.description,
       },
       { status: 500 },
     );

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -106,8 +106,8 @@ export async function POST(req: NextRequest) {
   } catch (error) {
     return NextResponse.json<ApiErrorSchema>(
       {
-        message: errorMessages.CANNOT_CREAT_RECIPE.message,
-        description: errorMessages.CANNOT_CREAT_RECIPE.description,
+        message: errorMessages.CANNOT_CREATE_RECIPE.message,
+        description: errorMessages.CANNOT_CREATE_RECIPE.description,
       },
       { status: 500 },
     );

--- a/src/features/recipe/hooks/use-recipe-creation.ts
+++ b/src/features/recipe/hooks/use-recipe-creation.ts
@@ -66,8 +66,8 @@ export function useRecipeCreation({
       setError({ message: err.message });
     } else {
       setError({
-        message: errorMessages.CANNOT_CREAT_RECIPE.message,
-        description: errorMessages.CANNOT_CREAT_RECIPE.description,
+        message: errorMessages.CANNOT_CREATE_RECIPE.message,
+        description: errorMessages.CANNOT_CREATE_RECIPE.description,
       });
     }
   };

--- a/src/features/recipe/libs/constants.ts
+++ b/src/features/recipe/libs/constants.ts
@@ -3,7 +3,7 @@ export const errorMessages = {
     message: "올바르지 않은 URL입니다.",
     description: "자막이 사용 가능한 YouTube 요리 영상의 URL을 입력해주세요.",
   },
-  CANNOT_CREAT_RECIPE: {
+  CANNOT_CREATE_RECIPE: {
     message: "레시피 생성에 실패했습니다.",
     description: "다시 시도해주세요.",
   },


### PR DESCRIPTION
## Summary
- correct `CANNOT_CREAT_RECIPE` typo to `CANNOT_CREATE_RECIPE`
- update API routes and recipe creation hook

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definition 'vitest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68462d9510d08320b46f4e8f689d6406